### PR TITLE
adds half-cut support for PT-E550W

### DIFF
--- a/brother_label/converter.py
+++ b/brother_label/converter.py
@@ -40,6 +40,7 @@ class BrotherLabelConverter(object):
             * **dpi_600**
             * **hq**
             * **threshold**
+            * **half_cut**
         """
         if not device:
             raise LookupError('No device available')
@@ -61,6 +62,7 @@ class BrotherLabelConverter(object):
         threshold = kwargs.get('threshold', 70)
         threshold = 100.0 - threshold
         threshold = min(255, max(0, int(threshold/100.0 * 255)))
+        half_cut = kwargs.get('half_cut', False)
 
         if red and not device.two_color:
             raise BrotherQLUnsupportedCmd('Printing in red is not supported with the selected model.')
@@ -181,6 +183,7 @@ class BrotherLabelConverter(object):
                 raster.dpi_600 = dpi_600
                 raster.cut_at_end = cut
                 raster.two_color_printing = True if red else False
+                raster.half_cut = half_cut
                 raster.add_expanded_mode()
             except BrotherQLUnsupportedCmd:
                 pass

--- a/brother_label/devices.py
+++ b/brother_label/devices.py
@@ -34,6 +34,9 @@ class BrotherDevice(object):
     #: Support for two color printing (black/red/white)
     #: available only on some newer models.
     two_color = attrib(type=bool, default=False)
+    #: Support for the 'half-cut' feature where labels are scored
+    #: and not fully cut. Supported by some P-Touch models.
+    half_cut = attrib(type=bool, default=False)
     #: Number of NULL bytes needed for the invalidate command.
     num_invalidate_bytes = attrib(type=int, default=200)
 
@@ -167,5 +170,5 @@ class BrotherDeviceManager(ElementManager):
             BrotherDevicePT('PT-P950NW', (57, 28346), number_bytes_per_row=70),
 
             # PTE Series
-            BrotherDevicePTE('PT-E550W',  (31, 14172), number_bytes_per_row=16),
+            BrotherDevicePTE('PT-E550W',  (31, 14172), number_bytes_per_row=16, half_cut=True),
         ))

--- a/brother_label/raster.py
+++ b/brother_label/raster.py
@@ -46,6 +46,7 @@ class BrotherLabelRaster(object):
         self.cut_at_end = True
         self.dpi_600 = False
         self.two_color_printing = False
+        self.half_cut = False
         self._compression = False
         self.exception_on_warning = False
 
@@ -170,6 +171,7 @@ class BrotherLabelRaster(object):
         flags |= self.cut_at_end << 3
         flags |= self.dpi_600 << 6
         flags |= self.two_color_printing << 0
+        flags |= self.half_cut << 2
         self.data += bytes([flags])
 
     def add_margins(self, dots=0x23):


### PR DESCRIPTION
# Summary

Adds support fort the "Half cut" option for Brother PT-E550W, with ability to enable other models as well.

# PR Details

PT-E550W, and likely some other models, supports a "half-cut" feature, which scores the labels, instead of fully cutting them.

This not only makes less mess, but when printing many labels at once, it saves a ton of tape.

The feature is described in the PDF **_Raster Command Reference, PT-E550W/P750W/P710BT, Version 1.02_**

I have added it as an option under the "expanded mode", and for E550W, as that's the label maker I have available to test.

I have tested it with my E550W and it works well for my needs. The only thing that would have been nicer is to figure out a way to have it cut at the end of _all_ labels, _and_ still do only half cut in between. This is the "stock" behavior.

However, it still works well with this simple change and and it's a huge improvement in terms of convenience and not wasting so much tape.

## Implementation

1. Added the `half_cut` attribute in the BrotherDevice class, and same option for the PT-E550W device attribute.
2. Added `half_cut` kwarg for `BrotherLabelConverter.convert()`.
3. Added a flag referencing the value of `self.half_cut` under `BrotherLabelRaster.add_expanded_mode()`. Second bit under Advanced Mode is the one controlling this option per the Brother PDF doc. 

## Testing Results

### With `cut=True` and other settings at defaults

Each label in the series has a short piece of tape fed in front of it, which is then cut off. Then a cut is made after each label, and the process repeats. 4 labels, 8 pieces of tape. Marked as **1** in photos below.

### With `cut=True`, `half_cut=True`

Each label in the series has a short piece of tape fed in front of it, which is then _scored_. The label image follows, and is fully cut after each label. 4 labels, 4 pieces of tape. Marked as **2** on the attached images.

![pte550w-half_cut-1](https://github.com/user-attachments/assets/6358760c-3942-4997-9ca2-727f67174d94)

### With `cut=False`, `half_cut=True`

First label has some tape fed in front, then scored after. Then after each label, the tape is scored again. No cutting occurs at the end (user has to initiate the cut). X labels = 1 piece of paper with labels scored. Marked as **3** in the second image.

![pte550w-half_cut-2](https://github.com/user-attachments/assets/42c8b4b6-943d-4529-b177-06264d7c1770)
