### PR TITLE
Add 6mm tape support for P-touch label printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ improvements and features planned, including:
 | QL-1115NWB       | Supported    |
 | PT-P750W         | Supported    |
 | PT-P900W         | Supported    |
-| PT-P950NW        | Supported    |
+| PT-P950NW        | ✔ Verified |
 | PT-E550W         | ✔️ Verified |
 
  - **Supported:** Device is supported, but no verification has been received.
@@ -48,7 +48,7 @@ improvements and features planned, including:
 
 | Type             | QL     | QL-10  | QL-11  | PT    | PT-E  |
 | ---------------- | ------ | ------ | ------ | ----- | ------ |
-| 6                | ❌    | ❌    | ❌    | ❌    | ✔️    |
+| 6                | ❌    | ❌    | ❌    | ✔     | ✔️    |
 | 9                | ❌    | ❌    | ❌    | ❌    | ✔️    |
 | 12               | ✔️    | ✔️    | ✔️    | ✔️    | ✔️    |
 | 18               | ✔️    | ✔️    | ✔️    | ✔️    | ✔️    |

--- a/brother_label/devices.py
+++ b/brother_label/devices.py
@@ -116,6 +116,7 @@ class BrotherDevicePT(BrotherDevice):
     def labels(self):
         return super().labels + [
             # Continuous
+            Label(["6",  "pt6"],                                (  6,   0), FormFactor.PTOUCH_ENDLESS,(  85,    0), (  64,    0),   255, feed_margin=14),
             Label(["12", "pt12"],                               ( 12,   0), FormFactor.PTOUCH_ENDLESS,( 170,    0), ( 150,    0),   213, feed_margin=14),
             Label(["18", "pt18"],                               ( 18,   0), FormFactor.PTOUCH_ENDLESS,( 256,    0), ( 234,    0),   171, feed_margin=14),
             Label(["24", "pt24"],                               ( 24,   0), FormFactor.PTOUCH_ENDLESS,( 128,    0), ( 128,    0),   0, feed_margin=14),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brother-label"
-version = "2.0a8"
+version = "2.0a9"
 description = "Brother label printer interface for QL and PT series printers."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Hi

I've used this library successfully to print 12mm labels using a PT-P950NW.

I also need 6mm support for this same device which 2.0a8 lacks. So, I made the necessary changes and tested them. All seemed fine. As a consequence, in this change I've also verified that the library works with a PT-P950NW device (to some extent).

What would be great now is to merge this tiny change to the master branch and release 2.0a9 that would "officially" support my missing use-case.

Given that this repo did not see any update since 11 Sep 2024, I'd also like to check if this library is still maintained and what the future plans are with it? I looked into the various available brother python libraries and this looked the most usable among them.

Kind regards
István
